### PR TITLE
deps: add interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "dependencies": {
     "async": "^2.5.0",
+    "bfx-facs-interval": "git+https://github.com/bitfinexcom/bfx-facs-interval.git",
     "lodash": "^4.17.4"
   },
   "engine": {


### PR DESCRIPTION
When working on this module, in this repository, linked into
a service, by `npm link`, the service would not start as the
dependency is missing