### PR TITLE
lifecycle: emit start event when ready

### DIFF
--- a/base.js
+++ b/base.js
@@ -3,9 +3,12 @@
 const fs = require('fs')
 const _ = require('lodash')
 const async = require('async')
+const EventEmitter = require('events')
 
-class Base {
+class Base extends EventEmitter {
   constructor (conf, ctx) {
+    super()
+
     this.conf = conf
     this.ctx = ctx
     this.wtype = ctx.wtype
@@ -168,7 +171,7 @@ class Base {
     }
   }
 
-  start (cb) {
+  start (cb = () => {}) {
     const aseries = []
 
     aseries.push(next => {
@@ -200,7 +203,13 @@ class Base {
       this._start(next)
     })
 
-    async.series(aseries, cb)
+    async.series(aseries, (err) => {
+      if (err) return cb(err)
+
+      process.nextTick(() => {
+        this.emit('started')
+      })
+    })
   }
 
   _start0 (cb) { cb() }


### PR DESCRIPTION
sometimes it takes a some time to start several facs, while a
service worker is still doing some other async task, e.g. in
`init`, `start()` or `start0`. because facs are loaded earlier
the grc-http fac then already announces the service on the
network.

this pr lets the worker emit an event when all bootstrap hooks
have finished.