### PR TITLE
adjusted config load to check for test prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/base.js
+++ b/base.js
@@ -53,13 +53,13 @@ class Base extends EventEmitter {
     const fprefix = this.ctx.env
     const dirname = join(this.ctx.root, 'config')
 
-    let confpath = join(dirname, `${c}.json`)
-    const testpath = join(dirname, `${fprefix}.${c}.json`)
-    if (fprefix && fs.existsSync(testpath)) {
-      confpath = testpath
+    let confPath = join(dirname, `${c}.json`)
+    const envConfPath = join(dirname, `${fprefix}.${c}.json`)
+    if (fprefix && fs.existsSync(envConfPath)) {
+      confPath = envConfPath
     }
 
-    _.merge(this.conf, this.getConf(this.ctx.env, group, confpath))
+    _.merge(this.conf, this.getConf(this.ctx.env, group, confPath))
 
     // e.g. util, coin or ext (i.e. derived from bfx-util-js)
     this.group = group

--- a/base.js
+++ b/base.js
@@ -50,7 +50,7 @@ class Base extends EventEmitter {
   }
 
   loadConf (c, group = null) {
-    const fprefix = this.ctx.env === 'test' ? 'test' : ''
+    const fprefix = this.ctx.env
     const dirname = join(this.ctx.root, 'config')
 
     let confpath = join(dirname, `${c}.json`)

--- a/base.js
+++ b/base.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fs = require('fs')
+const { join } = require('path')
 const _ = require('lodash')
 const async = require('async')
 const EventEmitter = require('events')
@@ -49,10 +50,16 @@ class Base extends EventEmitter {
   }
 
   loadConf (c, group = null) {
-    _.merge(
-      this.conf,
-      this.getConf(this.ctx.env, group, `${this.ctx.root}/config/${c}.json`)
-    )
+    const fprefix = this.ctx.env === 'test' ? 'test' : ''
+    const dirname = join(this.ctx.root, 'config')
+
+    let confpath = join(dirname, `${c}.json`)
+    const testpath = join(dirname, `${fprefix}.${c}.json`)
+    if (fprefix && fs.existsSync(testpath)) {
+      confpath = testpath
+    }
+
+    _.merge(this.conf, this.getConf(this.ctx.env, group, confpath))
 
     // e.g. util, coin or ext (i.e. derived from bfx-util-js)
     this.group = group


### PR DESCRIPTION
This PR adds support for `test.<configname>.json` files that would be loaded in case if `env` is `test`