### PR TITLE
feat: add JS config support

### DIFF
--- a/base.js
+++ b/base.js
@@ -29,7 +29,13 @@ class Base extends EventEmitter {
   }
 
   getConf (env, type, path) {
-    const conf = JSON.parse(fs.readFileSync(path, 'utf8'))
+    let conf
+    if (path.endsWith('.js')) {
+      conf = require(path)
+    } else {
+      conf = JSON.parse(fs.readFileSync(path, 'utf8'))
+    }
+
     if (!_.isObject(conf)) {
       return {}
     }
@@ -49,10 +55,20 @@ class Base extends EventEmitter {
     const fprefix = this.ctx.env
     const dirname = join(this.ctx.root, 'config')
 
-    let confPath = join(dirname, `${c}.json`)
-    const envConfPath = join(dirname, `${fprefix}.${c}.json`)
-    if (fprefix && fs.existsSync(envConfPath)) {
-      confPath = envConfPath
+    const baseJsonPath = join(dirname, `${c}.json`)
+    const envJsonPath = join(dirname, `${fprefix}.${c}.json`)
+    const baseJsPath = join(dirname, `${c}.js`)
+    const envJsPath = join(dirname, `${fprefix}.${c}.js`)
+
+    let confPath = baseJsonPath
+    if (fprefix && fs.existsSync(envJsonPath)) {
+      confPath = envJsonPath
+    } else if (fs.existsSync(baseJsonPath)) {
+      confPath = baseJsonPath
+    } else if (fprefix && fs.existsSync(envJsPath)) {
+      confPath = envJsPath
+    } else if (fs.existsSync(baseJsPath)) {
+      confPath = baseJsPath
     }
 
     _.merge(this.conf, this.getConf(this.ctx.env, group, confPath))

--- a/base.js
+++ b/base.js
@@ -55,12 +55,12 @@ class Base extends EventEmitter {
     const fprefix = this.ctx.env
     const dirname = join(this.ctx.root, 'config')
 
-    const baseJsonPath = join(dirname, `${c}.json`)
     const envJsonPath = join(dirname, `${fprefix}.${c}.json`)
-    const baseJsPath = join(dirname, `${c}.js`)
+    const baseJsonPath = join(dirname, `${c}.json`)
     const envJsPath = join(dirname, `${fprefix}.${c}.js`)
+    const baseJsPath = join(dirname, `${c}.js`)
 
-    const candidates = [baseJsonPath, envJsonPath, baseJsPath, envJsPath]
+    const candidates = [envJsonPath, baseJsonPath, envJsPath, baseJsPath]
     const confPath = candidates.find(p => fs.existsSync(p)) || baseJsonPath
 
     _.merge(this.conf, this.getConf(this.ctx.env, group, confPath))

--- a/base.js
+++ b/base.js
@@ -60,16 +60,8 @@ class Base extends EventEmitter {
     const baseJsPath = join(dirname, `${c}.js`)
     const envJsPath = join(dirname, `${fprefix}.${c}.js`)
 
-    let confPath = baseJsonPath
-    if (fprefix && fs.existsSync(envJsonPath)) {
-      confPath = envJsonPath
-    } else if (fs.existsSync(baseJsonPath)) {
-      confPath = baseJsonPath
-    } else if (fprefix && fs.existsSync(envJsPath)) {
-      confPath = envJsPath
-    } else if (fs.existsSync(baseJsPath)) {
-      confPath = baseJsPath
-    }
+    const candidates = [baseJsonPath, envJsonPath, baseJsPath, envJsPath]
+    const confPath = candidates.find(p => fs.existsSync(p)) || baseJsonPath
 
     _.merge(this.conf, this.getConf(this.ctx.env, group, confPath))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bitfinex/bfx-wrk-base",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitfinex/bfx-wrk-base",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.1",
-        "lodash": "^4.17.21"
+        "lodash": "^4.18.1"
       },
       "devDependencies": {
         "brittle": "^3.19.1",
@@ -221,10 +221,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1029,10 +1030,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2101,10 +2103,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3026,9 +3029,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3058,10 +3062,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3352,10 +3357,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -3885,6 +3891,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "eslint": "^8.41.0",
         "eslint-config-standard": "17.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "brittle": "^3.19.1",
-        "standard": "^17.1.2"
+        "standard": "^17.1.2",
+        "test-tmp": "^1.4.0"
       },
       "engines": {
         "node": ">=16.0"
@@ -4110,6 +4111,7 @@
       "resolved": "https://registry.npmjs.org/test-tmp/-/test-tmp-1.4.0.tgz",
       "integrity": "sha512-GVggxGg+jXqP2Wbju50JVLo+9E+nIOPPyWqgr63EbOnNItIKu1cEbJpTWAJeflnyGqXOtcMI7ijHRp88GUkfDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bare-fs": "^4.0.1",
         "bare-os": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinex/bfx-wrk-base",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": false,
   "description": "Bitfinex base worker",
   "scripts": {
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "async": "^3.2.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "brittle": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "devDependencies": {
     "brittle": "^3.19.1",
-    "standard": "^17.1.2"
+    "standard": "^17.1.2",
+    "test-tmp": "^1.4.0"
   },
   "engines": {
     "node": ">=16.0"

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -1,19 +1,124 @@
 'use strict'
 
 const { test } = require('brittle')
+const tmp = require('test-tmp')
+const path = require('path')
+const fs = require('fs')
+
 const Base = require('../base')
 
-test('Base unit tests', (t) => {
-  t.test('cleanFacName tests', (t) => {
-    const b = new Base({}, {})
+function createBase (dir, env) {
+  const ctx = { root: dir, env, wtype: 'test' }
+  return new Base({}, ctx)
+}
 
-    t.comment('should replace facility names until facs-')
-    t.is(b.cleanFacName('bfx-facs-db-mysql'), 'db-mysql')
+async function setupDir (t) {
+  const dir = await tmp(t)
+  fs.mkdirSync(path.join(dir, 'config'))
+  return dir
+}
 
-    t.comment('should work with scoped packages')
-    t.is(b.cleanFacName('@bitfinex/bfx-facs-db-mysql'), 'db-mysql')
+function writeConfig (dir, filename, content) {
+  const filePath = path.join(dir, 'config', filename)
+  const data = filename.endsWith('.js') ? content : JSON.stringify(content)
+  fs.writeFileSync(filePath, data)
+}
 
-    t.comment('should return fullname if package does not have facs')
-    t.is(b.cleanFacName('@bitfinex/bfx-db-mysql'), '@bitfinex/bfx-db-mysql')
+test('cleanFacName', (t) => {
+  const b = new Base({}, {})
+
+  t.comment('should replace facility names until facs-')
+  t.is(b.cleanFacName('bfx-facs-db-mysql'), 'db-mysql')
+
+  t.comment('should work with scoped packages')
+  t.is(b.cleanFacName('@bitfinex/bfx-facs-db-mysql'), 'db-mysql')
+
+  t.comment('should return fullname if package does not have facs')
+  t.is(b.cleanFacName('@bitfinex/bfx-db-mysql'), '@bitfinex/bfx-db-mysql')
+})
+
+test('JSON config resolution', async (t) => {
+  await t.test('loads base JSON config if env is not provided', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'common.json', { key: 'value', nested: { a: 1 } })
+    writeConfig(dir, 'production.common.json', { key: 'env-specific' })
+
+    const base = createBase(dir)
+    base.loadConf('common')
+    t.alike(base.conf, { key: 'value', nested: { a: 1 } })
+  })
+
+  await t.test('loads env-specific JSON config over base others', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'common.json', { key: 'base' })
+    writeConfig(dir, 'production.common.json', { key: 'prod-env-specific' })
+    writeConfig(dir, 'development.common.json', { key: 'dev-env-specific' })
+
+    const base = createBase(dir, 'production')
+    base.loadConf('common')
+    t.is(base.conf.key, 'prod-env-specific')
+  })
+
+  await t.test('falls back to base JSON if env-specific JSON is missing', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'common.json', { key: 'base' })
+
+    const base = createBase(dir, 'production')
+    base.loadConf('common')
+    t.is(base.conf.key, 'base')
+  })
+})
+
+test('JS config resolution', async (t) => {
+  await t.test('loads base JS config when no JSON exists', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'common.js', "module.exports = { key: 'from-js' }")
+
+    const base = createBase(dir)
+    base.loadConf('common')
+    t.is(base.conf.key, 'from-js')
+  })
+
+  await t.test('loads env-specific JS config when no JSON exists and env is provided', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'development.common.js', "module.exports = { key: 'dev-env-js' }")
+    writeConfig(dir, 'production.common.js', "module.exports = { key: 'prod-js' }")
+
+    const base = createBase(dir, 'development')
+    base.loadConf('common')
+    t.is(base.conf.key, 'dev-env-js')
+  })
+
+  await t.test('falls back to base JS if env-specific JS is missing and no JSON exists', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'common.js', "module.exports = { key: 'base-js' }")
+
+    const base = createBase(dir, 'production')
+    base.loadConf('common')
+    t.is(base.conf.key, 'base-js')
+  })
+})
+
+test('config priority order', async (t) => {
+  await t.test('JSON config takes priority over JS config', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'common.json', { source: 'json' })
+    writeConfig(dir, 'common.js', "module.exports = { source: 'js' }")
+
+    const base = createBase(dir)
+    base.loadConf('common')
+    t.is(base.conf.source, 'json')
+  })
+
+  await t.test('env-specific JSON has highest priority', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'production.common.json', { source: 'env-json' })
+    writeConfig(dir, 'common.json', { source: 'base-json' })
+    writeConfig(dir, 'production.common.js', "module.exports = { source: 'env-js' }")
+    writeConfig(dir, 'common.js', "module.exports = { source: 'base-js' }")
+
+    const base = createBase(dir, 'production')
+    base.loadConf('common')
+    t.is(base.conf.source, 'env-json')
   })
 })


### PR DESCRIPTION
Adds support for loading configuration from .js files in addition to .json files.

## Changes
- Updated `loadConf()` to check for .js files after .json files
- Updated `getConf()` to use `require()` for JS files

## Related PRs
This is part of the JS config support feature across multiple repos.